### PR TITLE
Input 2

### DIFF
--- a/src/main/scala/InputTest.scala
+++ b/src/main/scala/InputTest.scala
@@ -1,23 +1,17 @@
-import java.io.PrintStream
-import java.net.ServerSocket
-
-import org.apache.spark.storage.StorageLevel
-import org.apache.spark.{SparkConf, streaming}
-import org.apache.spark.streaming.{StreamingContext, Seconds}
+import org.apache.spark.SparkConf
+import org.apache.spark.streaming.{Seconds, StreamingContext}
 import rx.lang.scala.Observable
 import wrapper.Helper._
+
 import scala.concurrent.duration._
 
-/**
- * Created by Niels on 17-3-2015.
- */
 object InputTest {
 
   def main(args: Array[String]): Unit = {
     // Create the context with a 1 second batch size. The "local[3]" means 3 threads.
     val sparkConf = new SparkConf().setMaster("local[3]").setAppName("IntervalObs")
     val ssc = new StreamingContext(sparkConf, Seconds(1))
-    
+
     val obs = Observable.interval(1 seconds)
 
     val stream = obs.toDStream(ssc)

--- a/src/main/scala/InputTest.scala
+++ b/src/main/scala/InputTest.scala
@@ -13,12 +13,27 @@ object InputTest {
     val ssc = new StreamingContext(sparkConf, Seconds(1))
 
     val obs = Observable.interval(1 seconds)
+    val yoloObs = obs.map(x => new Yolo(x.toString))
 
-    val stream = obs.toDStream(ssc)
-    stream.foreachRDD(x => x.foreach(println))
+    // Turn our observable into a DStream
+    val stream = yoloObs.toDStream(ssc)
+
+    // Let our workers do heavy computations on our Yolo objects
+    val stream2 = stream.map(y => y.heavyComputation())
+
+    // Get back the results and print those
+    stream2.foreachRDD(x => x.foreach(println))
 
     ssc.start()
     ssc.awaitTermination()
   }
 
+}
+
+class Yolo(val number: String) extends Serializable {
+  def heavyComputation() = {
+    Thread.sleep(3)
+    
+    new Integer(number) * 2
+  }
 }


### PR DESCRIPTION
This is a new attempt at using an `Observable` as input stream for Spark. New insights learned us that the _driver program_ is responsible for creating a socket and distributing batches of data to worker nodes. The _driver program_ is supposed to run on a separate node, so the code for the driver program is serialised and run elsewhere. This makes it impossible to directly plug an Observable into Spark.

To overcome this limitation, we now set up a server in the _user program_ to which the _driver program_ starts listening. Every value emitted by the observable is pushed from the _user program_ over the socket to the _driver program_. The _driver program_ then distributes this among the workers.

Still a WIP and still trying to figure out if this server is really necessary.
