### PR TITLE
Backpressure on input observable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # RxSpark
+
+Assignment for the course Reactive Programming (IN4389) at Delft University of Technology. The assignment is:
+
+> Create Rx bindings for Spark Streaming http://ampcamp.berkeley.edu/3/exercises/realtime-processing-with-spark-streaming.html
+
+## Logging
+
+The logging level can be changed in src/main/resources/log4j.properties. Don't forget to run the program with
+`-Dlog4j.configurationd=src/resources/log4j.properties` as VM argument.

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,14 +1,14 @@
 # Set everything to be logged to the console
-log4j.rootCategory=ERROR, console
+#log4j.rootCategory=ERROR, console
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
 
 # Change this to set Spark log level
-log4j.logger.org.apache.spark=ERROR
+#log4j.logger.org.apache.spark=ERROR
 
 # Silence akka remoting
-log4j.logger.Remoting=ERROR
+#log4j.logger.Remoting=ERROR
 
 # Ignore messages below warning level from Jetty, because it's a bit verbose
-log4j.logger.org.eclipse.jetty=ERROR
+#log4j.logger.org.eclipse.jetty=ERROR

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,14 +1,10 @@
-<<<<<<< HEAD
 import org.apache.spark.SparkConf
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.StreamingContext._
 import org.apache.spark.streaming.{Seconds, StreamingContext}
+import rx.lang.scala.Observable
 import wrapper.Helper._
 
-import org.apache.log4j.Logger
-import org.apache.spark.streaming.{Seconds, StreamingContext}
-import org.apache.spark.{SparkContext, SparkConf}
-import rx.lang.scala.Observable
 import scala.concurrent.duration._
 
 object Main {
@@ -38,7 +34,7 @@ object Main {
 
       println("Count: " + rdd.count())
     })
-    
+
     ssc.start()
     ssc.awaitTermination()
   }

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -6,8 +6,6 @@ import wrapper.Helper._
 import scala.concurrent.duration._
 
 object Main {
-  val clock = Observable.interval(100 milliseconds)
-
   def main(args: Array[String]): Unit = {
     // Create the context with a 1 second batch size. The "local[3]" means 3 threads.
     val sparkConf = new SparkConf()
@@ -24,7 +22,7 @@ object Main {
     stream
       .toObservable
       .subscribe(l => println("Observable says: " + l))
-
+    
     ssc.start()
     ssc.awaitTermination()
   }

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,15 +1,19 @@
+<<<<<<< HEAD
 import org.apache.spark.SparkConf
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.StreamingContext._
 import org.apache.spark.streaming.{Seconds, StreamingContext}
 import wrapper.Helper._
 
+import org.apache.log4j.Logger
 import org.apache.spark.streaming.{Seconds, StreamingContext}
 import org.apache.spark.{SparkContext, SparkConf}
 import rx.lang.scala.Observable
 import scala.concurrent.duration._
 
 object Main {
+  val clock = Observable.interval(100 milliseconds)
+
   def main(args: Array[String]): Unit = {
     // Create the context with a 1 second batch size. The "local[3]" means 3 threads.
     val sparkConf = new SparkConf().setMaster("local[3]").setAppName("NetworkWordCount")
@@ -25,6 +29,16 @@ object Main {
       .toObservable
       .subscribe(l => println("Observable says: " + l))
 
+    wordCounts.foreachRDD(rdd => {
+      val top = rdd.take(10)
+
+      top.foreach(x => {
+        println("Item: " + x)
+      })
+
+      println("Count: " + rdd.count())
+    })
+    
     ssc.start()
     ssc.awaitTermination()
   }

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -4,6 +4,11 @@ import org.apache.spark.streaming.StreamingContext._
 import org.apache.spark.streaming.{Seconds, StreamingContext}
 import wrapper.Helper._
 
+import org.apache.spark.streaming.{Seconds, StreamingContext}
+import org.apache.spark.{SparkContext, SparkConf}
+import rx.lang.scala.Observable
+import scala.concurrent.duration._
+
 object Main {
   def main(args: Array[String]): Unit = {
     // Create the context with a 1 second batch size. The "local[3]" means 3 threads.

--- a/src/main/scala/RxUtils.scala
+++ b/src/main/scala/RxUtils.scala
@@ -1,0 +1,29 @@
+import org.apache.spark.Logging
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.streaming.StreamingContext
+import org.apache.spark.streaming.dstream.ReceiverInputDStream
+import org.apache.spark.streaming.receiver.Receiver
+import rx.lang.scala.Observable
+
+object RxUtils {
+  def createStream(scc_ : StreamingContext, observable: Observable[Long]): ReceiverInputDStream[Long] = {
+    new RxInputDStream(scc_, observable, StorageLevel.MEMORY_AND_DISK_SER_2)
+  }
+}
+
+class RxInputDStream(ssc_ : StreamingContext, observable: Observable[Long], storageLevel: StorageLevel) extends ReceiverInputDStream[Long](ssc_)  {
+  override def getReceiver(): Receiver[Long] = {
+    new RxReceiver(observable, storageLevel)
+  }
+}
+
+class RxReceiver[T](observable: Observable[T], storageLevel: StorageLevel) extends Receiver[T](storageLevel) with Logging {
+  override def onStart(): Unit = {
+    logInfo("Rx receiver started")
+    observable.subscribe(store(_))
+  }
+
+  override def onStop(): Unit = {
+    logInfo("Rx receiver stopped")
+  }
+}

--- a/src/main/scala/RxUtils.scala
+++ b/src/main/scala/RxUtils.scala
@@ -20,7 +20,9 @@ class RxInputDStream(ssc_ : StreamingContext, observable: Observable[Long], stor
 class RxReceiver[T](observable: Observable[T], storageLevel: StorageLevel) extends Receiver[T](storageLevel) with Logging {
   override def onStart(): Unit = {
     logInfo("Rx receiver started")
-    observable.subscribe(store(_))
+//    observable.subscribe(store(_))
+    (Main.clock.asInstanceOf[Observable[T]])
+      .subscribe(x => store(x))
   }
 
   override def onStop(): Unit = {

--- a/src/main/scala/RxUtils.scala
+++ b/src/main/scala/RxUtils.scala
@@ -3,29 +3,44 @@ import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.StreamingContext
 import org.apache.spark.streaming.dstream.ReceiverInputDStream
 import org.apache.spark.streaming.receiver.Receiver
-import rx.lang.scala.Observable
+import rx.lang.scala.{Subscription, Observable}
+
+import scala.reflect.ClassTag
 
 object RxUtils {
-  def createStream(scc_ : StreamingContext, observable: Observable[Long]): ReceiverInputDStream[Long] = {
-    new RxInputDStream(scc_, observable, StorageLevel.MEMORY_AND_DISK_SER_2)
+  def createStream[T: ClassTag](scc_ : StreamingContext, observable: Observable[T]): ReceiverInputDStream[T] = {
+    new RxInputDStream[T](scc_, observable, StorageLevel.MEMORY_AND_DISK_SER_2)
   }
 }
 
-class RxInputDStream(ssc_ : StreamingContext, observable: Observable[Long], storageLevel: StorageLevel) extends ReceiverInputDStream[Long](ssc_)  {
-  override def getReceiver(): Receiver[Long] = {
+class RxInputDStream[T: ClassTag](ssc_ : StreamingContext, observable: Observable[T], storageLevel: StorageLevel) extends ReceiverInputDStream[T](ssc_)  {
+  override def getReceiver(): Receiver[T] = {
     new RxReceiver(observable, storageLevel)
   }
 }
 
 class RxReceiver[T](observable: Observable[T], storageLevel: StorageLevel) extends Receiver[T](storageLevel) with Logging {
+  var subscription: Option[Subscription] = None
+
+  /**
+   * Subscribe to the observable when Spark signals to start.
+   */
   override def onStart(): Unit = {
+    subscription = Some(
+      Main.clock
+        .asInstanceOf[Observable[T]]
+        .subscribe(x => store(x))
+    )
+
     logInfo("Rx receiver started")
-//    observable.subscribe(store(_))
-    (Main.clock.asInstanceOf[Observable[T]])
-      .subscribe(x => store(x))
   }
 
+  /**
+   * Unsubscribe from the observable when Spark signals to stop.
+   */
   override def onStop(): Unit = {
+    subscription.map(_.unsubscribe())
+
     logInfo("Rx receiver stopped")
   }
 }

--- a/src/main/scala/wrapper/Helper.scala
+++ b/src/main/scala/wrapper/Helper.scala
@@ -1,39 +1,12 @@
 package wrapper
 
-import java.io.PrintStream
-import java.net.ServerSocket
-
-import org.apache.spark.storage.StorageLevel
-import org.apache.spark.streaming.StreamingContext
 import org.apache.spark.streaming.dstream.DStream
 import rx.lang.scala.Observable
 
 object Helper {
-
   implicit class DStreamWrapper[T](stream: DStream[T]) {
     def toObservable = Observable[T](subscriber =>
       stream.foreachRDD(_.collect().map(subscriber.onNext))
     )
   }
-
-  implicit class ObservableWrapper(obs: Observable[Long]) {
-    def toDStream(ssc: StreamingContext) = {
-      new Thread() {
-        override def run: Unit = {
-
-          val server = new ServerSocket(9999)
-          val s = server.accept()
-          println("Client connected")
-          val out = new PrintStream(s.getOutputStream)
-
-          obs.subscribe(x => out.println(x))
-          while (true) {}
-        }
-      }.start
-
-
-      ssc.socketTextStream("localhost", 9999, StorageLevel.MEMORY_AND_DISK_SER)
-    }
-  }
-
 }


### PR DESCRIPTION
Puts backpressure on the input observable. Currently, the queued job sets are used as an indicator of the load in the system. Spark is not really extensible, so to access this information I had to fork Spark. See MartijnDwars/spark.
